### PR TITLE
Requirements - Pin django-storages==1.6.6 (as 1.7 requires django>=1.11)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'click',
 
         # storage
-        'django-storages',
+        'django-storages==1.6.6',
         'boto>=2.40.0',
         'djeese-fs',
 


### PR DESCRIPTION
- On 2nd September 2018, django-storages 1.7 was released.  
- django-storages>=1.7 requires django>=1.11. 
- This conflicts with aldryn-django==1.8.x which requires django==1.8.x, resulting in build failures. 

-- Singh @ Compound Partners LTD